### PR TITLE
Tolerate invalid user rows

### DIFF
--- a/packages/frisky-girl-farm-api/src/sheets/users-sheet.js
+++ b/packages/frisky-girl-farm-api/src/sheets/users-sheet.js
@@ -38,6 +38,10 @@ class UsersSheet extends Sheet {
     let [, ...userRows] = await this.getAll({ majorDimension: 'ROWS' });
     let users = [];
     for (let row of userRows) {
+      if (!row[emailColumnIndex]) {
+        continue;
+      }
+
       if (userIds.includes(row[emailColumnIndex].trim())) {
         users.push({
           // Tolerate accidental whitespace, and trim it out when generating the email

--- a/packages/frisky-girl-farm-api/test/users-sheet-test.js
+++ b/packages/frisky-girl-farm-api/test/users-sheet-test.js
@@ -20,6 +20,8 @@ describe('UsersSheet', function () {
         100.0,
         65.0,
       ],
+      // Make sure some extra garbage data doesn't mess things up
+      [null, null, null, 0, null, null],
     ]);
 
     sheet = new UsersSheet({


### PR DESCRIPTION
If there's a little garbage in the users sheet, then we can get rows back with null email address columns, which was causing us to throw an error. So, guard against that.