### PR TITLE
Fix past order month display

### DIFF
--- a/packages/frisky-girl-farm/app/helpers/monday-date.ts
+++ b/packages/frisky-girl-farm/app/helpers/monday-date.ts
@@ -5,14 +5,18 @@ export function mondayDate([date]: [Date]) {
   let day = d.getDay();
   let dayDelta;
   if (day === 0) {
-    // sunday
+    // sunday, which we think of as at the end of the week-starting-on-monday,
+    // so we need to subtract six days from the date to get back to the sunday
     dayDelta = 6;
   } else {
+    // not a sunday, so subtract one less than the day value to get back to the
+    // monday (which has a value of 1)
     dayDelta = day - 1;
   }
 
   let monday = new Date(d.setDate(d.getDate() - dayDelta));
-  return `${monday.getMonth() - 1}-${monday.getDate()}`;
+  // getMonth() is 0-based, getDate() isn't
+  return `${monday.getMonth() + 1}-${monday.getDate()}`;
 }
 
 export default helper(mondayDate);


### PR DESCRIPTION
We were correcting a off-by-one the wrong way, making it an off-by-two error! So fix it and comment things up a little while I have this logic crammed back in my head.